### PR TITLE
Add `--temp-dir` and `--gfa-list` parameters

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ struct Args {
     #[clap(long)]
     fasta: Option<String>,
 
-    /// Working directory for temporary files (default: same as input files)
+    /// Temporary directory for temporary files (default: same as input files)
     #[clap(long, value_parser)]
     temp_dir: Option<String>,
 


### PR DESCRIPTION
The `--temp-dir` parameter allows us to specify a fast temporary directory when working with compressed GFA files.
The  `--gfa-list`  parameter helps when there are lots of GFA files to specify.