### PR TITLE
Validate path range lengths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -625,15 +625,68 @@ fn read_gfa_files(
         }
     });
 
-    // Unwrap the Arc/Mutex wrappers now that all threads have finished
-    let graph = Arc::try_unwrap(combined_graph)
-        .ok()
-        .expect("More than one Arc pointer to graph")
-        .into_inner()
-        .unwrap();
+    // Unwrap the Arc/Mutex wrapper for path_key_ranges now that all threads have finished
     let path_map = Arc::try_unwrap(path_key_ranges)
         .ok()
         .expect("More than one Arc pointer to path map")
+        .into_inner()
+        .unwrap();
+
+    // Validate all path ranges in parallel using the still-wrapped graph
+    info!("Validating path range lengths");
+    let validation_errors: Vec<String> = path_map
+        .par_iter()
+        .flat_map(|(path_key, ranges)| {
+            ranges
+                .par_iter()
+                .filter_map(|range| {
+                    let expected_length = range.end - range.start;
+                    let mut actual_length = 0;
+                    
+                    // Compute actual length by summing step lengths
+                    for &step_handle in &range.steps {
+                        let seq_result = {
+                            let mut graph = combined_graph.lock().unwrap();
+                            graph.get_sequence(step_handle)
+                        };
+                        
+                        match seq_result {
+                            Ok(seq) => actual_length += seq.len(),
+                            Err(e) => {
+                                return Some(format!(
+                                    "Failed to get sequence for node {} in path {}: {}",
+                                    step_handle.id(), path_key, e
+                                ));
+                            }
+                        }
+                    }
+                    
+                    if expected_length != actual_length {
+                        Some(format!(
+                            "Path range length mismatch for '{}:{}-{}': \
+                             expected length {} but sum of step lengths is {}",
+                            path_key, range.start, range.end, expected_length, actual_length
+                        ))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<String>>()
+        })
+        .collect();
+
+    // Check if there were any validation errors
+    if !validation_errors.is_empty() {
+        for error in validation_errors {
+            error!("{}", error);
+        }
+        std::process::exit(1);
+    }
+
+    // Now unwrap the graph after validation is complete
+    let graph = Arc::try_unwrap(combined_graph)
+        .ok()
+        .expect("More than one Arc pointer to graph")
         .into_inner()
         .unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -621,6 +621,7 @@ fn read_gfa_files(
             );
         } else {
             error!("Failed to open GFA file '{}'", gfa_path);
+            std::process::exit(1);
         }
     });
 
@@ -1315,7 +1316,7 @@ fn create_gap_node<W: Write>(
                     }
                 }
                 Err(e) => {
-                    error!("Failed to open FASTA file '{}': {}", fasta_path, e);
+                    warn!("Failed to open FASTA file '{}': {}", fasta_path, e);
                     "N".repeat(gap_size)
                 }
             }


### PR DESCRIPTION
`poasta` sometimes returns GFA files where the lengths of the path ranges (the subpath `name:start-end` has `len=end-start`) are different from the sum of the lengths of the steps corresponding to those ranges.

For example, the subpath `ciao:0-10` has an expected length of 10 bp, but adding all the step lengths from the POASTAed graph the length is greater than 10!

We add a validation check after reading the GFA files to lace.